### PR TITLE
Update SplitStatement to use non-pointer to fix build

### DIFF
--- a/sqliteparserutils/utils.go
+++ b/sqliteparserutils/utils.go
@@ -17,7 +17,7 @@ type SplitStatementExtraInfo struct {
 func SplitStatement(statement string) (stmts []string, extraInfo SplitStatementExtraInfo) {
 	tokenStream := createTokenStream(statement)
 
-	stmtIntervals := make([]*antlr.Interval, 0)
+	stmtIntervals := make([]antlr.Interval, 0)
 	currentIntervalStart := -1
 	insideCreateTriggerStmt := false
 	insideMultilineComment := false


### PR DESCRIPTION
This repository is currently in a broken state. The `SplitStatement` function declares a slice of the wrong type 

```diff
- stmtIntervals := make([]*antlr.Interval, 0)
+ stmtIntervals := make([]antlr.Interval, 0)
```

The underlying package that fills the slice returns a struct, and not a pointer to a struct.

https://pkg.go.dev/github.com/antlr4-go/antlr/v4#NewInterval

This PR updates the declaration to the correct type, which fixes the following Go errors:

```
go vet ./sqliteparserutils/...   
# github.com/libsql/sqlite-antlr4-parser/sqliteparserutils
sqliteparserutils/utils.go:57:42: cannot use antlr.NewInterval(currentIntervalStart, previousToken.GetTokenIndex()) (value of type antlr.Interval) as *antlr.Interval value in argument to append
sqliteparserutils/utils.go:66:41: cannot use antlr.NewInterval(currentIntervalStart, previousToken.GetTokenIndex()) (value of type antlr.Interval) as *antlr.Interval value in argument to append
sqliteparserutils/utils.go:71:57: cannot use stmtInterval (variable of type *antlr.Interval) as antlr.Interval value in argument to tokenStream.GetTextFromInterval`
```