### PR TITLE
"streaming" parsing

### DIFF
--- a/sqliteparserutils/buffered_tokenizer.go
+++ b/sqliteparserutils/buffered_tokenizer.go
@@ -6,23 +6,23 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 )
 
-// BufferedTokenizer preload few next tokens and put them in the tokens buffer to support look-ahead access with limited distance
+// bufferedTokenizer preload few next tokens and put them in the tokens buffer to support look-ahead access with limited distance
 // Tokenizer maintains loaded tokens in ring buffer and use constant memory to support all requests (which is important for streaming mode)
-type BufferedTokenizer struct {
+type bufferedTokenizer struct {
 	source antlr.TokenSource
 	tokens []antlr.Token
 	index  int
 }
 
 // createBufferedTokenizer initialize tokenizer which will store current token and bufferSize-1 next tokens for look-ahead accesses
-func createBufferedTokenizer(source antlr.TokenSource, bufferSize int) *BufferedTokenizer {
+func createBufferedTokenizer(source antlr.TokenSource, bufferSize int) *bufferedTokenizer {
 	tokens := make([]antlr.Token, bufferSize)
-	stream := BufferedTokenizer{source: source, tokens: tokens, index: 0}
+	stream := bufferedTokenizer{source: source, tokens: tokens, index: 0}
 	stream.load(bufferSize)
 	return &stream
 }
 
-func (stream *BufferedTokenizer) load(n int) {
+func (stream *bufferedTokenizer) load(n int) {
 	i := 0
 	for i < n {
 		token := stream.source.NextToken()
@@ -35,18 +35,18 @@ func (stream *BufferedTokenizer) load(n int) {
 	stream.index = (stream.index + i) % len(stream.tokens)
 }
 
-func (stream *BufferedTokenizer) Consume() {
+func (stream *bufferedTokenizer) Consume() {
 	stream.load(1)
 	return
 }
 
-func (stream *BufferedTokenizer) Get(k int) antlr.Token {
+func (stream *bufferedTokenizer) Get(k int) antlr.Token {
 	if k >= len(stream.tokens) {
 		panic(fmt.Errorf("out of buffer read attempts: %d >= %d", k, len(stream.tokens)))
 	}
 	return stream.tokens[(stream.index+k)%len(stream.tokens)]
 }
 
-func (stream *BufferedTokenizer) IsEOF() bool {
+func (stream *bufferedTokenizer) IsEOF() bool {
 	return stream.Get(0).GetTokenType() == antlr.TokenEOF
 }

--- a/sqliteparserutils/buffered_tokenizer.go
+++ b/sqliteparserutils/buffered_tokenizer.go
@@ -1,0 +1,52 @@
+package sqliteparserutils
+
+import (
+	"fmt"
+
+	"github.com/antlr4-go/antlr/v4"
+)
+
+// BufferedTokenizer preload few next tokens and put them in the tokens buffer to support look-ahead access with limited distance
+// Tokenizer maintains loaded tokens in ring buffer and use constant memory to support all requests (which is important for streaming mode)
+type BufferedTokenizer struct {
+	source antlr.TokenSource
+	tokens []antlr.Token
+	index  int
+}
+
+// createBufferedTokenizer initialize tokenizer which will store current token and bufferSize-1 next tokens for look-ahead accesses
+func createBufferedTokenizer(source antlr.TokenSource, bufferSize int) *BufferedTokenizer {
+	tokens := make([]antlr.Token, bufferSize)
+	stream := BufferedTokenizer{source: source, tokens: tokens, index: 0}
+	stream.load(bufferSize)
+	return &stream
+}
+
+func (stream *BufferedTokenizer) load(n int) {
+	i := 0
+	for i < n {
+		token := stream.source.NextToken()
+		if token.GetChannel() != antlr.TokenDefaultChannel {
+			continue
+		}
+		stream.tokens[(stream.index+i)%len(stream.tokens)] = token
+		i += 1
+	}
+	stream.index = (stream.index + i) % len(stream.tokens)
+}
+
+func (stream *BufferedTokenizer) Consume() {
+	stream.load(1)
+	return
+}
+
+func (stream *BufferedTokenizer) Get(k int) antlr.Token {
+	if k >= len(stream.tokens) {
+		panic(fmt.Errorf("out of buffer read attempts: %d >= %d", k, len(stream.tokens)))
+	}
+	return stream.tokens[(stream.index+k)%len(stream.tokens)]
+}
+
+func (stream *BufferedTokenizer) IsEOF() bool {
+	return stream.Get(0).GetTokenType() == antlr.TokenEOF
+}

--- a/sqliteparserutils/utils.go
+++ b/sqliteparserutils/utils.go
@@ -19,7 +19,8 @@ type StatementIterator struct {
 	currentToken antlr.Token
 }
 
-func CreateStatementIterator(statement string) *StatementIterator {
+// keep createStatementIterator here for the future uses but do not expose it for now as we will not use it immediately
+func createStatementIterator(statement string) *StatementIterator {
 	return &StatementIterator{tokenizer: createStringTokenizer(statement)}
 }
 
@@ -76,7 +77,7 @@ func (iterator *StatementIterator) Next() (statement string, extraInfo SplitStat
 }
 
 func SplitStatement(statement string) (statements []string, extraInfo SplitStatementExtraInfo) {
-	iterator := CreateStatementIterator(statement)
+	iterator := createStatementIterator(statement)
 
 	statements = make([]string, 0)
 	for {

--- a/sqliteparserutils/utils.go
+++ b/sqliteparserutils/utils.go
@@ -15,7 +15,7 @@ type SplitStatementExtraInfo struct {
 }
 
 type StatementIterator struct {
-	tokenizer    *BufferedTokenizer
+	tokenizer    *bufferedTokenizer
 	currentToken antlr.Token
 }
 
@@ -90,7 +90,7 @@ func SplitStatement(statement string) (statements []string, extraInfo SplitState
 	}
 }
 
-func atCreateTriggerStart(tokenStream *BufferedTokenizer) bool {
+func atCreateTriggerStart(tokenStream *bufferedTokenizer) bool {
 	token1 := tokenStream.Get(0).GetTokenType()
 	token2 := tokenStream.Get(1).GetTokenType()
 	token3 := tokenStream.Get(2).GetTokenType()
@@ -108,13 +108,13 @@ func atCreateTriggerStart(tokenStream *BufferedTokenizer) bool {
 
 // Note: Only starts for incomplete multiline comments will be detected cause lexer automatically ignores complete
 // multiline comments
-func atIncompleteMultilineCommentStart(stream *BufferedTokenizer) bool {
+func atIncompleteMultilineCommentStart(stream *bufferedTokenizer) bool {
 	token1 := stream.Get(0).GetTokenType()
 	token2 := stream.Get(1).GetTokenType()
 	return token1 == sqliteparser.SQLiteLexerDIV && token2 == sqliteparser.SQLiteLexerSTAR
 }
 
-func createStringTokenizer(statement string) *BufferedTokenizer {
+func createStringTokenizer(statement string) *bufferedTokenizer {
 	statementStream := antlr.NewInputStream(statement)
 
 	lexer := sqliteparser.NewSQLiteLexer(statementStream)

--- a/sqliteparserutils/utils_bench_test.go
+++ b/sqliteparserutils/utils_bench_test.go
@@ -1,0 +1,25 @@
+package sqliteparserutils
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func BenchmarkSplitStatement(b *testing.B) {
+	var (
+		mem   runtime.MemStats
+		count = 8192
+	)
+
+	hugeStatement := strings.Repeat("INSERT INTO t VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);", count)
+	for i := 0; i < b.N; i++ {
+		statements, _ := SplitStatement(hugeStatement)
+		if len(statements) != count {
+			b.Fail()
+		}
+		// these intermediate logs can help to estimate memory working set (instead of total allocations)
+		runtime.ReadMemStats(&mem)
+		b.Logf("heap in use: %v", mem.HeapInuse)
+	}
+}

--- a/sqliteparserutils/utils_test.go
+++ b/sqliteparserutils/utils_test.go
@@ -158,6 +158,12 @@ func TestSplitStatement(t *testing.T) {
 			extraInfo: generateSimpleSplitStatementExtraInfo(sqliteparser.SQLiteLexerEND_),
 		},
 		{
+			name:      "CompleteCreateTempTriggerStatement",
+			value:     "CREATE TEMP TRIGGER update_updated_at AFTER UPDATE ON users FOR EACH ROW BEGIN UPDATE users SET updated_at = 0 WHERE id = NEW.id; END",
+			stmts:     []string{"CREATE TEMP TRIGGER update_updated_at AFTER UPDATE ON users FOR EACH ROW BEGIN UPDATE users SET updated_at = 0 WHERE id = NEW.id; END"},
+			extraInfo: generateSimpleSplitStatementExtraInfo(sqliteparser.SQLiteLexerEND_),
+		},
+		{
 			name:      "IncompleteCreateTriggerStatement",
 			value:     "CREATE TRIGGER update_updated_at AFTER UPDATE ON users FOR EACH ROW BEGIN UPDATE users SET updated_at = 0 WHERE id = NEW.id;",
 			stmts:     []string{"CREATE TRIGGER update_updated_at AFTER UPDATE ON users FOR EACH ROW BEGIN UPDATE users SET updated_at = 0 WHERE id = NEW.id;"},


### PR DESCRIPTION
## Context

There are known issue in turso-cli about high memory consumption for huge dumps loaded to libsql (see https://github.com/tursodatabase/turso-cli/issues/735).

`sqlite-antlr4-parser` is one of the contributors for this issue. There are several problems with current implementation:
1. It supports only `string` input and doesn't support streaming inputs (`io.Reader`). This forces caller to load all query to the memory
2. During the parsing `SplitStatement` implementation uses `antlr.CommonTokenStream` stream which preserve all previously seen tokens in the buffer

While first problem definitely cause inevitable suboptimal behaviour for streaming data - it's pretty hard to change because `antlr.NewIoStream` also loads all data in memory before processing and streaming adoption requires a lot of changes and tweaks on the caller side.

So, we must concentrate on the second factor which is pretty easy to optimize. 

This PR refactor parsing logic and uses simple `bufferedTokenizer` instead of `antlr.CommonTokenStream`. 

`bufferedTokenizer` just keep a buffer for `K` next tokens in order to support look-ahead access requests and this is enough for parser use case.

Some benchmark numbers (`BenchmarkSplitStatement` test):
```
benchstat old new
goos: linux
goarch: amd64
pkg: github.com/libsql/sqlite-antlr4-parser/sqliteparserutils
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
                 │     old     │                 new                 │
                 │   sec/op    │   sec/op     vs base                │
SplitStatement-8   83.71m ± 2%   55.95m ± 2%  -33.16% (p=0.000 n=32)

                 │     old      │                 new                  │
                 │     B/op     │     B/op      vs base                │
SplitStatement-8   71.26Mi ± 0%   31.89Mi ± 0%  -55.25% (p=0.000 n=32)

                 │     old     │                 new                 │
                 │  allocs/op  │  allocs/op   vs base                │
SplitStatement-8   934.0k ± 0%   327.7k ± 0%  -64.91% (p=0.000 n=32)
```

The main benefit however is not reflected on Go benchmarks because this PR drastically improves working set usage. We can see this in the benchmark logs:
```
$> head -n 10 old
?   	github.com/libsql/sqlite-antlr4-parser/sqliteparser	[no test files]
goos: linux
goarch: amd64
pkg: github.com/libsql/sqlite-antlr4-parser/sqliteparserutils
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkSplitStatement-8   	      14	  77382354 ns/op	74722955 B/op	  933986 allocs/op
--- BENCH: BenchmarkSplitStatement-8
    utils_bench_test.go:22: heap in use: 58769408
$> head -n 10 new
?   	github.com/libsql/sqlite-antlr4-parser/sqliteparser	[no test files]
goos: linux
goarch: amd64
pkg: github.com/libsql/sqlite-antlr4-parser/sqliteparserutils
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkSplitStatement-8   	      20	  56963239 ns/op	33443111 B/op	  327731 allocs/op
--- BENCH: BenchmarkSplitStatement-8
    utils_bench_test.go:23: heap in use: 8306688
```

We estimate from this log that working memory set size reduced 7x from `56 MB` to `8 MB`

## Changes

- Implement `bufferedTokenizer`
- Refactor split statements logic
- Expose `StatementIterator` and `CreateStatementIterator` methods (can be helpful in future to not store all statements and process them in streaming fashion)
- Add `BenchmarkSplitStatement` simple benchmark
- Add test for TEMP triggers

## Testing

- Unit tests are passed